### PR TITLE
chore: add Claude Code project configuration (#1)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "enabledMcpjsonServers": [
+    "context7",
+    "mcp-nixos",
+    "mcp-server-git",
+    "memory",
+    "sequential-thinking"
+  ]
+}

--- a/.claude/skills/git-commit/SKILL.md
+++ b/.claude/skills/git-commit/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: git-commit
+description: >
+  Write well-formed git commit messages following Conventional Commits, enforce issue references,
+  and ensure commit bodies explain why — not what. Use this skill whenever you are about to run
+  git commit, stage changes, or need to produce a commit message. Also use it when helping with
+  any git workflow that involves committing: feature branches, bug fixes, CI automation, or
+  autonomous agent loops.
+---
+
+# Git Commit Skill
+
+You are about to create a git commit. Follow every rule here — these conventions keep the project
+history readable by humans and parseable by tools, now and years from now.
+
+## Step 1 — Understand what changed
+
+Run these commands to understand the full picture:
+
+```bash
+git status
+git diff --staged        # what will be committed
+git diff                 # what is still unstaged (decide if it belongs in this commit)
+git branch --show-current
+git log --oneline -5
+```
+
+Read the output carefully. Commit one coherent unit of work. If staged changes span multiple
+unrelated concerns, split them into separate commits.
+
+## Step 2 — Find the issue number
+
+Every commit must reference a GitHub issue. This is non-negotiable. Look in this order:
+
+1. **Branch name** — extract the number from patterns like `feature/123-...`, `fix/123`,
+   `123-slug`, `issue-123`, `GH-123`.
+2. **Recent commits** — if the last few commits all reference `#42`, this work likely belongs there.
+3. **Conversation or task context** — the user or task description may have mentioned an issue.
+
+**If you cannot find an issue number, stop completely.** Do not stage, do not commit. Instead,
+tell the user:
+
+> No GitHub issue found for this work. Please create one before committing — a commit must
+> always trace back to an issue. Once you have the issue number, let me know and I will
+> proceed with the commit.
+
+Do not invent a number. Do not use a placeholder. Do not proceed until the user provides a
+real issue number.
+
+## Step 3 — Write the commit message
+
+### Subject line (first line)
+
+Format: `type(scope): description #issue`
+
+Rules:
+- **type** must be exactly one of: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`,
+  `chore`, `ci`, `build` — no other values.
+- **scope** is optional. Use it when it meaningfully narrows the context (e.g., `feat(auth):`,
+  `fix(api):`). Omit it when the change is broad or the scope is self-evident.
+- **description** is lowercase, imperative mood ("add", "fix", not "added" or "fixes"), no
+  trailing period.
+- **#issue** goes at the very end, separated by a space.
+- The entire subject line must be **72 characters or fewer**. Count them. Shorten if needed.
+
+Examples:
+```
+feat(auth): add JWT refresh token rotation #42
+fix(api): handle nil pointer in user lookup #87
+chore: upgrade Go toolchain to 1.23 #101
+docs: add setup instructions to README #15
+```
+
+### Body (optional but strongly encouraged)
+
+Leave a blank line after the subject, then write the body. The body answers **why** — not what.
+The diff shows what changed. The body explains the reasoning: the bug that was observed, the
+constraint encountered, the decision that was made.
+
+Bad body: "Added retry logic to the HTTP client."
+Good body: "The upstream API intermittently returns 503 under load. Without retries, user-facing
+requests fail hard. Three retries with exponential backoff keeps the error rate below 0.1%."
+
+Keep body lines under 72 characters.
+
+### Full example
+
+```
+fix(api): return 404 when resource is soft-deleted #88
+
+Soft-deleted records were being returned in GET responses, leaking
+data that users had explicitly removed. The ORM default scope was
+not filtering on deleted_at, which we now enforce at the model level.
+```
+
+## Step 4 — Commit
+
+Stage the relevant files and commit. Do not use `--no-verify`. Do not amend an existing commit
+unless the user has explicitly asked for it.
+
+```bash
+git add <relevant files>
+git commit -m "$(cat <<'EOF'
+type(scope): description #issue
+
+Optional body explaining why.
+EOF
+)"
+```
+
+## Commit often
+
+For autonomous agent workflows, prefer many small coherent commits over one large one. Scaffolding,
+implementation, tests, and documentation are usually separate commits. This makes review, bisect,
+and revert tractable.
+
+If you find yourself writing "and" in the subject line, it probably needs to be two commits.

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: issue
+description: >
+  Expand a rough idea into a well-structured, actionable issue — then create it in the right
+  tracker (GitHub, Linear, Jira). Use this skill whenever a user wants to create an issue,
+  report a bug, propose a feature, request an improvement, or track any piece of work — even
+  if they don't use the word "issue". Trigger on phrases like "I'd like a...", "we should
+  add...", "there's a bug with...", "can we track...", "let's make an issue for...", or any
+  description of desired functionality or a problem that needs solving. Don't wait for the
+  user to ask explicitly — if they describe something that should be tracked, offer to create
+  an issue.
+---
+
+# Issue Creator
+
+Your goal is to turn a rough idea into a well-structured, actionable issue — then create it
+in the right tracker. Work iteratively: ask focused questions, build understanding, and only
+create the issue when it's genuinely worth making.
+
+## Step 1 — Detect the tracker
+
+Before asking anything else, figure out where issues live for this project. Check in order:
+
+1. **CLAUDE.md or any `.claude/*.md` files** — look for mentions of GitHub, Linear, Jira,
+   project keys, or tracker URLs
+2. **`.github/` directory** — its presence strongly implies GitHub Issues
+3. **`package.json`, `pyproject.toml`, `go.mod`** — repo metadata sometimes includes tracker links
+4. **Git remote URL** — a `github.com` remote means GitHub Issues is available
+
+If the tracker is unambiguous, proceed silently. If it is unclear or multiple trackers are
+present, ask the user once: *"What issue tracker does this project use? (GitHub / Linear /
+Jira / other)"*
+
+Keep the tracker in mind — you will need it at the end.
+
+## Step 2 — Understand the rough idea
+
+Read what the user gave you. Before asking anything, identify the gaps:
+
+- **Why does this matter?** — Is the motivation clear? Who is affected?
+- **What does "done" look like?** — Can you describe acceptance criteria?
+- **What is the scope?** — Is it clear what's in and out?
+- **How should it work?** — Are there implementation decisions or preferences to surface?
+- **Are there alternatives?** — Should we build it ourselves or use an existing library/package?
+
+## Step 3 — Iterative questioning
+
+Ask 2–3 focused questions per round — the most important gaps first. Don't dump every
+question at once; pick what matters most right now. After each answer, reassess: do you
+have enough, or is another round needed?
+
+**Keep asking until the issue has all of these:**
+- A clear problem statement and motivation (the *why*)
+- Defined scope (what's in, what's out)
+- Verifiable acceptance criteria (what does "done" look like?)
+- Key implementation context or open decisions surfaced
+
+**Good questions to draw from (use judgment, not a checklist):**
+- What problem does this solve? Who runs into this and when?
+- What should it look/feel/behave like? Any examples or references?
+- Should we use an existing package, or build it ourselves?
+- What are the edge cases or failure modes we should handle?
+- What would you check to confirm it's working?
+- Is anything explicitly out of scope for this issue?
+- Are there related issues, PRs, or prior art we should reference?
+- What's the priority — nice-to-have, or blocking something?
+
+Be conversational. Don't interview the user — have a dialogue. If an answer raises a new
+question, follow up on it before moving on.
+
+## Step 4 — Draft the issue
+
+Once you have enough context, produce a Markdown draft using this structure:
+
+```
+## Problem / Motivation
+
+Why does this matter? What problem does it solve, and for whom?
+Describe the "before" state — what's missing, broken, or frustrating.
+
+## Proposed Solution
+
+What should be built or changed? High-level description of the approach.
+If there are meaningful alternatives considered, mention them briefly.
+
+## Acceptance Criteria
+
+- [ ] Specific, verifiable condition that defines "done"
+- [ ] Another condition
+- [ ] ...
+
+## Implementation Notes
+
+Key decisions, preferred approaches, packages to consider, constraints.
+(Omit this section if there is nothing meaningful to say)
+
+## Open Questions
+
+- Anything still uncertain that should be resolved during implementation
+(Omit this section if none)
+```
+
+Show the draft to the user:
+
+> Here's the draft. Does this capture it correctly? Anything to add, change, or cut before
+> I create it?
+
+Apply any edits. Get a clear yes before proceeding.
+
+## Step 5 — Create the issue
+
+Use the right MCP tool for the detected tracker:
+
+### GitHub
+
+Use `mcp__plugin_github_github__issue_write`. You need:
+- `owner` and `repo` — derive from the git remote (`git remote get-url origin`), or ask
+- `title` — concise, imperative ("Add progress bar to model download")
+- `body` — the full Markdown draft
+
+### Linear
+
+Authenticate first if needed (`mcp__claude_ai_Linear__authenticate`), then use the
+appropriate Linear MCP tool. You need:
+- Team or project identifier — check context files, or ask
+- Title and description
+
+### Jira
+
+Authenticate first if needed (`mcp__claude_ai_Atlassian__authenticate`), then use the
+appropriate Atlassian MCP tool. You need:
+- Project key — check context files, or ask
+- Summary (title) and description
+
+### Other trackers
+
+If the tracker has an MCP integration, use it. If not, output the formatted Markdown so
+the user can paste it themselves, and say so clearly.
+
+---
+
+After creating, share the issue URL or ID so the user can find it immediately.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: pr
+description: >
+  Create a well-structured GitHub pull request that gives the reviewer full context: what
+  issue is being addressed, what problem it solves, what changed, why, and how to verify.
+  Use this skill whenever you are about to run `gh pr create`, open a pull request, or produce
+  a PR for completed work. Also use it at the end of any autonomous agent loop that resolves
+  a GitHub issue — even if the user didn't explicitly ask for a PR.
+---
+
+# PR Skill
+
+You are about to open a pull request. A good PR lets the reviewer understand the work without
+having to reverse-engineer the diff. Follow every step.
+
+## Step 1 — Verify you are on a branch
+
+```bash
+git branch --show-current
+```
+
+If the output is `main`, **stop immediately**:
+
+> You are on `main`. A pull request requires a feature branch. Create one for this work
+> before opening a PR.
+
+Do not proceed until you are on a non-main branch.
+
+## Step 2 — Find the issue number
+
+Every PR must reference a GitHub issue. Look in this order:
+
+1. **Branch name** — extract from patterns like `feature/123-...`, `fix/123`,
+   `issue/123-slug`, `123-slug`, `GH-123`.
+2. **Recent commits** — if the commits on this branch reference `#42`, that is likely the issue.
+3. **Conversation or task context** — the user or task description may have stated it.
+
+If you cannot find an issue number, **stop completely**:
+
+> No GitHub issue found for this work. Please provide the issue number — every PR must
+> trace back to an issue.
+
+Do not invent a number. Do not use a placeholder. Do not proceed without a real issue number.
+
+## Step 3 — Understand what changed
+
+Run these commands before writing a single word of the PR:
+
+```bash
+git log main..HEAD --oneline          # commits on this branch
+git diff main..HEAD --stat            # files changed, lines added/removed
+git diff main..HEAD                   # full diff
+gh issue view <number>                # the problem statement and acceptance criteria
+```
+
+Read everything. The issue tells you the *problem*. The diff shows the *solution*.
+The commit log shows the *sequence of decisions*. You need all three to write a good PR.
+
+## Step 4 — Write the PR
+
+### Title
+
+Format: `type(scope): description (#issue)`
+
+Same rules as commit messages:
+- **type**: `feat`, `fix`, `docs`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`
+- **scope**: optional — use it when it meaningfully narrows the context
+- **description**: lowercase, imperative mood ("add", "fix", not "added" or "fixes"), no trailing period
+- **72 characters or fewer** — count them
+
+```
+feat(auth): add JWT refresh token rotation (#42)
+fix(api): handle nil pointer in user lookup (#87)
+chore: upgrade Go toolchain to 1.23 (#101)
+```
+
+### Body
+
+Use this exact structure — every section, every time:
+
+```
+Closes #<issue>
+
+## Problem
+
+<What was broken, missing, or needed. Describe the "before" state: what happened, what
+failed, what was absent. One to three sentences. Pull from the issue body if it explains
+it well — don't reinvent it.>
+
+## Changes
+
+<Bullet list of what was changed. Files, components, behaviours. Focus on the what —
+keep it scannable. Don't pad this with obvious things like "updated tests"; mention
+the things a reviewer will actually want to navigate to.>
+
+- ...
+- ...
+
+## Why
+
+<The reasoning. Why this approach and not another? What constraint or insight drove the
+design? If a simpler solution was rejected, say why. Be honest about trade-offs. This
+is the section that ages best — six months from now, nobody will remember why, and this
+is where they'll look.>
+
+## How to verify
+
+<Step-by-step instructions a reviewer can follow to confirm the changes work. Concrete
+enough that someone unfamiliar can execute it. If there are tests, name them. If it's a
+CLI command, write it out. If it requires setup, say so.>
+
+1. ...
+2. ...
+```
+
+Keep each section proportional to the change. A one-line fix doesn't need three
+paragraphs. A significant refactor deserves real detail. Don't pad; don't omit.
+
+## Step 5 — Create the PR
+
+```bash
+gh pr create \
+  --title "<title>" \
+  --body "$(cat <<'EOF'
+Closes #<issue>
+
+## Problem
+
+<problem>
+
+## Changes
+
+<changes>
+
+## Why
+
+<why>
+
+## How to verify
+
+<how-to-verify>
+EOF
+)" \
+  --base main
+```
+
+After the PR is created, output the URL so the user can find it immediately.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.mcp.json


### PR DESCRIPTION
Closes #1

## Problem

Contributors using Claude Code as their AI agent had no project-specific configuration. Without it, Claude Code runs with bare defaults — no MCP servers enabled, no custom skills — so issue creation, PR creation, and git commits don't follow project conventions automatically.

## Changes

- `.claude/settings.local.json` — enables MCP servers: `context7`, `mcp-nixos`, `mcp-server-git`, `memory`, `sequential-thinking`
- `.claude/skills/git-commit/SKILL.md` — skill enforcing Conventional Commits format with mandatory issue references
- `.claude/skills/issue/SKILL.md` — skill for creating well-structured, iteratively-refined GitHub issues
- `.claude/skills/pr/SKILL.md` — skill for creating PRs with full reviewer context (problem, changes, why, how to verify)
- `.gitignore` — excludes `.mcp.json` (machine-local MCP config, not committed)

## Why

The skills encode conventions that would otherwise have to be re-explained to Claude Code every session. By committing them to the repo, any contributor gets the same structured output from day one without having to configure anything manually. The MCP servers extend Claude Code's toolset (docs lookup, Nix queries, git operations, persistent memory) in a way that's consistent across machines.

`.mcp.json` is excluded because it holds paths and credentials specific to each developer's machine — committing it would either break other contributors' setups or require constant merge conflicts.

## How to verify

1. Open the repo in Claude Code (or run `claude` in the project root).
2. Run `/git-commit` — confirm it enforces Conventional Commits format and requires an issue number.
3. Run `/issue` — confirm it prompts for structured issue details before creating.
4. Run `/pr` — confirm it checks for a feature branch and generates a structured PR body.
5. Confirm `.mcp.json` does not appear as a tracked file (`git status` should not list it even if the file exists locally).